### PR TITLE
Dev surveys admin

### DIFF
--- a/api/src/main/java/com/uib/avaluapp/global/exceptions/ExceptionCode.java
+++ b/api/src/main/java/com/uib/avaluapp/global/exceptions/ExceptionCode.java
@@ -21,7 +21,10 @@ public enum ExceptionCode {
 
     // Project related exceptions
     PROJECT_NOT_FOUND("Project not found", HttpStatus.NOT_FOUND),
-    PROJECT_UNAUTHORIZED("You are not authorized to access this project", HttpStatus.FORBIDDEN);
+    PROJECT_UNAUTHORIZED("You are not authorized to access this project", HttpStatus.FORBIDDEN),
+
+    // Survey related exceptions
+    SURVEY_NOT_FOUND("Survey not found", HttpStatus.NOT_FOUND);
 
 
     private final String message;

--- a/api/src/main/java/com/uib/avaluapp/project/infrastructure/data/models/ProjectEntity.java
+++ b/api/src/main/java/com/uib/avaluapp/project/infrastructure/data/models/ProjectEntity.java
@@ -1,10 +1,12 @@
 package com.uib.avaluapp.project.infrastructure.data.models;
 
+import com.uib.avaluapp.surveys.infrastructure.data.models.SurveyEntity;
 import com.uib.avaluapp.user.infrastructure.data.models.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "project")
@@ -30,6 +32,9 @@ public class ProjectEntity {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "admin_id", nullable = false)
     private UserEntity admin;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SurveyEntity> surveys;
 
     @PrePersist
     protected void onCreate() {

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/models/Survey.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/models/Survey.java
@@ -1,0 +1,20 @@
+package com.uib.avaluapp.surveys.domain.models;
+
+import com.uib.avaluapp.project.domain.models.Project;
+import com.uib.avaluapp.user.domain.models.User;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class Survey {
+    private Long id;
+    private String name;
+    private LocalDateTime createdAt;
+    private String urlCode;
+    private SurveyStatus status;
+    private User lead;
+    private Project project;
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/models/SurveyStatus.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/models/SurveyStatus.java
@@ -1,0 +1,7 @@
+package com.uib.avaluapp.surveys.domain.models;
+
+public enum SurveyStatus {
+    PENDING,
+    REJECTED,
+    ACCEPTED
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/ports/SurveyPort.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/ports/SurveyPort.java
@@ -1,0 +1,19 @@
+package com.uib.avaluapp.surveys.domain.ports;
+
+import com.uib.avaluapp.surveys.domain.models.Survey;
+
+import java.util.List;
+
+public interface SurveyPort {
+    Survey fetchLead(Survey survey);
+
+    Survey fetchProject(Survey survey);
+
+    List<Survey> getAllSurveysByProjectId(Long projectId);
+
+    Survey createSurvey(Survey survey);
+
+    void deleteSurvey(Long surveyId);
+
+    Survey updateSurvey(Survey survey);
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyService.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyService.java
@@ -1,0 +1,16 @@
+package com.uib.avaluapp.surveys.domain.services;
+
+import com.uib.avaluapp.surveys.infrastructure.web.requests.CreateSurveyRequest;
+import com.uib.avaluapp.surveys.infrastructure.web.responses.SurveyDto;
+
+import java.util.List;
+
+public interface SurveyService {
+    List<SurveyDto> getAllSurveys(String authorization, Long projectId);
+
+    SurveyDto createSurvey(String authorization, CreateSurveyRequest request);
+
+    void deleteSurvey(String authorization, Long surveyId);
+
+    SurveyDto updateSurvey(String authorization, Long surveyId, CreateSurveyRequest request);
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyServiceImpl.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyServiceImpl.java
@@ -89,6 +89,6 @@ public class SurveyServiceImpl implements SurveyService {
         survey.setName(request.getName());
         survey.setLead(lead);
 
-        return SurveyDtoMapper.INSTANCE.toDto(surveyPort.createSurvey(survey));
+        return SurveyDtoMapper.INSTANCE.toDto(surveyPort.updateSurvey(survey));
     }
 }

--- a/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyServiceImpl.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/domain/services/SurveyServiceImpl.java
@@ -1,0 +1,94 @@
+package com.uib.avaluapp.surveys.domain.services;
+
+import com.uib.avaluapp.global.exceptions.BaseException;
+import com.uib.avaluapp.global.exceptions.ExceptionCode;
+import com.uib.avaluapp.project.domain.models.Project;
+import com.uib.avaluapp.project.domain.ports.ProjectPort;
+import com.uib.avaluapp.surveys.domain.models.Survey;
+import com.uib.avaluapp.surveys.domain.ports.SurveyPort;
+import com.uib.avaluapp.surveys.infrastructure.web.SurveyDtoMapper;
+import com.uib.avaluapp.surveys.infrastructure.web.requests.CreateSurveyRequest;
+import com.uib.avaluapp.surveys.infrastructure.web.responses.SurveyDto;
+import com.uib.avaluapp.user.domain.models.User;
+import com.uib.avaluapp.user.domain.ports.UserPort;
+import com.uib.avaluapp.user.domain.services.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyServiceImpl implements SurveyService {
+
+    private final UserService userService;
+    private final SurveyPort surveyPort;
+    private final ProjectPort projectPort;
+    private final UserPort userPort;
+
+    @Override
+    public List<SurveyDto> getAllSurveys(String authorization, Long projectId) {
+        User admin = userService.getSingleUser(authorization);
+
+        Project project = projectPort.getProjectById(projectId);
+        if (!project.getAdmin().getId().equals(admin.getId())) {
+            throw new BaseException(ExceptionCode.PROJECT_UNAUTHORIZED);
+        }
+
+        List<Survey> surveys = surveyPort.getAllSurveysByProjectId(projectId)
+                .stream()
+                .map(surveyPort::fetchLead)
+                .toList();
+
+        return SurveyDtoMapper.INSTANCE.toDtoList(surveys);
+    }
+
+    @Override
+    public SurveyDto createSurvey(String authorization, CreateSurveyRequest request) {
+        User admin = userService.getSingleUser(authorization);
+
+        Project project = projectPort.getProjectById(request.getProjectId());
+        if (!project.getAdmin().getId().equals(admin.getId())) {
+            throw new BaseException(ExceptionCode.PROJECT_UNAUTHORIZED);
+        }
+
+        User lead = userPort.getSingleUser(request.getLeadId());
+
+        Survey survey = Survey.builder()
+                .name(request.getName())
+                .project(project)
+                .lead(lead)
+                .build();
+
+        return SurveyDtoMapper.INSTANCE.toDto(surveyPort.createSurvey(survey));
+    }
+
+    @Override
+    public void deleteSurvey(String authorization, Long surveyId) {
+        User admin = userService.getSingleUser(authorization);
+        Survey survey = surveyPort.fetchProject(Survey.builder().id(surveyId).build());
+
+        if (!survey.getProject().getAdmin().getId().equals(admin.getId())) {
+            throw new BaseException(ExceptionCode.PROJECT_UNAUTHORIZED);
+        }
+
+        surveyPort.deleteSurvey(surveyId);
+    }
+
+    @Override
+    public SurveyDto updateSurvey(String authorization, Long surveyId, CreateSurveyRequest request) {
+        User admin = userService.getSingleUser(authorization);
+        Survey survey = surveyPort.fetchProject(Survey.builder().id(surveyId).build());
+
+        if (!survey.getProject().getAdmin().getId().equals(admin.getId())) {
+            throw new BaseException(ExceptionCode.PROJECT_UNAUTHORIZED);
+        }
+
+        User lead = userPort.getSingleUser(request.getLeadId());
+
+        survey.setName(request.getName());
+        survey.setLead(lead);
+
+        return SurveyDtoMapper.INSTANCE.toDto(surveyPort.createSurvey(survey));
+    }
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/adapters/SurveyAdapter.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/adapters/SurveyAdapter.java
@@ -1,0 +1,69 @@
+package com.uib.avaluapp.surveys.infrastructure.data.adapters;
+
+import com.uib.avaluapp.global.exceptions.BaseException;
+import com.uib.avaluapp.global.exceptions.ExceptionCode;
+import com.uib.avaluapp.surveys.domain.models.Survey;
+import com.uib.avaluapp.surveys.domain.ports.SurveyPort;
+import com.uib.avaluapp.surveys.infrastructure.data.models.SurveyEntity;
+import com.uib.avaluapp.surveys.infrastructure.data.repository.SurveyRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SurveyAdapter implements SurveyPort {
+    private final SurveyRepository surveyRepository;
+
+    public SurveyAdapter(SurveyRepository surveyRepository) {
+        this.surveyRepository = surveyRepository;
+    }
+
+    @Override
+    public Survey fetchLead(Survey survey) {
+        Long id = survey.getId();
+        return surveyRepository.findWithLead(id)
+                .map(SurveyEntityMapper.INSTANCE::toDomain)
+                .orElseThrow(() -> new BaseException(ExceptionCode.SURVEY_NOT_FOUND));
+    }
+
+    @Override
+    public Survey fetchProject(Survey survey) {
+        Long id = survey.getId();
+        return surveyRepository.findWithProject(id)
+                .map(SurveyEntityMapper.INSTANCE::toDomain)
+                .orElseThrow(() -> new BaseException(ExceptionCode.SURVEY_NOT_FOUND));
+    }
+
+    @Override
+    public List<Survey> getAllSurveysByProjectId(Long projectId) {
+        return surveyRepository.findAllByProjectId(projectId)
+                .stream()
+                .map(SurveyEntityMapper.INSTANCE::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Survey createSurvey(Survey survey) {
+        SurveyEntity entity = surveyRepository.save(SurveyEntityMapper.INSTANCE.toEntity(survey));
+        return SurveyEntityMapper.INSTANCE.toDomain(entity);
+    }
+
+    @Override
+    public void deleteSurvey(Long surveyId) {
+        if (!surveyRepository.existsById(surveyId)) {
+            throw new BaseException(ExceptionCode.SURVEY_NOT_FOUND);
+        }
+
+        surveyRepository.deleteById(surveyId);
+    }
+
+    @Override
+    public Survey updateSurvey(Survey survey) {
+        if (!surveyRepository.existsById(survey.getId())) {
+            throw new BaseException(ExceptionCode.SURVEY_NOT_FOUND);
+        }
+
+        SurveyEntity entity = surveyRepository.save(SurveyEntityMapper.INSTANCE.toEntity(survey));
+        return SurveyEntityMapper.INSTANCE.toDomain(entity);
+    }
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/adapters/SurveyEntityMapper.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/adapters/SurveyEntityMapper.java
@@ -1,0 +1,25 @@
+package com.uib.avaluapp.surveys.infrastructure.data.adapters;
+
+import com.uib.avaluapp.project.infrastructure.data.adapters.ProjectEntityMapper;
+import com.uib.avaluapp.surveys.domain.models.Survey;
+import com.uib.avaluapp.surveys.infrastructure.data.models.SurveyEntity;
+import com.uib.avaluapp.user.infrastructure.data.adapters.UserEntityMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper(uses = {UserEntityMapper.class, ProjectEntityMapper.class})
+public interface SurveyEntityMapper {
+    SurveyEntityMapper INSTANCE = Mappers.getMapper(SurveyEntityMapper.class);
+
+    SurveyEntity toEntity(Survey survey);
+
+    Survey toDomain(SurveyEntity surveyEntity);
+
+    default List<Survey> toDomainList(List<SurveyEntity> surveyEntities) {
+        return surveyEntities.stream()
+                .map(this::toDomain)
+                .toList();
+    }
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/models/SurveyEntity.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/models/SurveyEntity.java
@@ -1,0 +1,56 @@
+package com.uib.avaluapp.surveys.infrastructure.data.models;
+
+import com.uib.avaluapp.project.infrastructure.data.models.ProjectEntity;
+import com.uib.avaluapp.surveys.domain.models.SurveyStatus;
+import com.uib.avaluapp.user.infrastructure.data.models.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "survey")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@Builder
+public class SurveyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "url_code", nullable = false, unique = true, updatable = false)
+    private String urlCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SurveyStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lead_id")
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private UserEntity lead;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private ProjectEntity project;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.status = SurveyStatus.PENDING;
+        if (this.urlCode == null || this.urlCode.isEmpty()) {
+            this.urlCode = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/repository/SurveyRepository.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/repository/SurveyRepository.java
@@ -1,0 +1,19 @@
+package com.uib.avaluapp.surveys.infrastructure.data.repository;
+
+import com.uib.avaluapp.surveys.infrastructure.data.models.SurveyEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SurveyRepository extends CrudRepository<SurveyEntity, Long> {
+    @Query("SELECT s FROM SurveyEntity s LEFT JOIN FETCH s.lead WHERE s.id = :id")
+    Optional<SurveyEntity> findWithLead(@Param("id") Long id);
+
+    @Query("SELECT s FROM SurveyEntity s LEFT JOIN FETCH s.project WHERE s.id = :id")
+    Optional<SurveyEntity> findWithProject(@Param("id") Long id);
+
+    List<SurveyEntity> findAllByProjectId(Long projectId);
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyController.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyController.java
@@ -1,0 +1,87 @@
+package com.uib.avaluapp.surveys.infrastructure.web;
+
+import com.uib.avaluapp.auth.domain.services.JwtService;
+import com.uib.avaluapp.global.insfrastructure.web.BaseController;
+import com.uib.avaluapp.global.insfrastructure.web.config.HandleConfig;
+import com.uib.avaluapp.global.insfrastructure.web.response.ApiResponse;
+import com.uib.avaluapp.surveys.domain.services.SurveyService;
+import com.uib.avaluapp.surveys.infrastructure.web.requests.CreateSurveyRequest;
+import com.uib.avaluapp.surveys.infrastructure.web.responses.SurveyDto;
+import com.uib.avaluapp.user.domain.ports.UserPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/surveys")
+public class SurveyController extends BaseController {
+    private final SurveyService surveyService;
+
+    @Autowired
+    public SurveyController(SurveyService surveyService,
+                            JwtService jwtService,
+                            UserPort userPort) {
+        super(jwtService, userPort);
+        this.surveyService = surveyService;
+    }
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ApiResponse<List<SurveyDto>>> getAllSurveys(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long projectId) {
+        HandleConfig<List<SurveyDto>> config = HandleConfig.<List<SurveyDto>>builder()
+                .authorization(authorization)
+                .successMessage("Surveys retrieved successfully")
+                .successStatus(HttpStatus.OK)
+                .adminHandler(() -> surveyService.getAllSurveys(authorization, projectId))
+                .build();
+
+        return handle(config);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SurveyDto>> createSurvey(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody CreateSurveyRequest request) {
+        HandleConfig<SurveyDto> config = HandleConfig.<SurveyDto>builder()
+                .authorization(authorization)
+                .successMessage("Survey created successfully")
+                .successStatus(HttpStatus.CREATED)
+                .adminHandler(() -> surveyService.createSurvey(authorization, request))
+                .build();
+
+        return handle(config);
+    }
+
+    @DeleteMapping("/{surveyId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSurvey(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long surveyId) {
+        HandleConfig<Void> config = HandleConfig.<Void>builder()
+                .authorization(authorization)
+                .successMessage("Survey deleted successfully")
+                .successStatus(HttpStatus.NO_CONTENT)
+                .adminHandler(HandleConfig.from(() -> surveyService.deleteSurvey(authorization, surveyId)))
+                .build();
+
+        return handle(config);
+    }
+
+    @PutMapping("/{surveyId}")
+    public ResponseEntity<ApiResponse<SurveyDto>> updateSurvey(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long surveyId,
+            @RequestBody CreateSurveyRequest request) {
+        HandleConfig<SurveyDto> config = HandleConfig.<SurveyDto>builder()
+                .authorization(authorization)
+                .successMessage("Survey updated successfully")
+                .successStatus(HttpStatus.OK)
+                .adminHandler(() -> surveyService.updateSurvey(authorization, surveyId, request))
+                .build();
+
+        return handle(config);
+    }
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyDtoMapper.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyDtoMapper.java
@@ -1,0 +1,19 @@
+package com.uib.avaluapp.surveys.infrastructure.web;
+
+import com.uib.avaluapp.project.infrastructure.web.ProjectDtoMapper;
+import com.uib.avaluapp.surveys.domain.models.Survey;
+import com.uib.avaluapp.surveys.infrastructure.web.responses.SurveyDto;
+import com.uib.avaluapp.user.infrastructure.web.UserDtoMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper(uses = {UserDtoMapper.class, ProjectDtoMapper.class})
+public interface SurveyDtoMapper {
+    SurveyDtoMapper INSTANCE = Mappers.getMapper(SurveyDtoMapper.class);
+
+    SurveyDto toDto(Survey survey);
+
+    List<SurveyDto> toDtoList(List<Survey> surveys);
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/requests/CreateSurveyRequest.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/requests/CreateSurveyRequest.java
@@ -1,0 +1,12 @@
+package com.uib.avaluapp.surveys.infrastructure.web.requests;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateSurveyRequest {
+    private String name;
+    private Long leadId;
+    private Long projectId;
+}

--- a/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/responses/SurveyDto.java
+++ b/api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/responses/SurveyDto.java
@@ -1,0 +1,18 @@
+package com.uib.avaluapp.surveys.infrastructure.web.responses;
+
+import com.uib.avaluapp.project.infrastructure.web.responses.ProjectDto;
+import com.uib.avaluapp.user.infrastructure.web.responses.UserDto;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SurveyDto {
+    private Long id;
+    private String name;
+    private String createdAt;
+    private String urlCode;
+    private String status;
+    private UserDto lead;
+    private ProjectDto project;
+}

--- a/api/src/main/java/com/uib/avaluapp/user/infrastructure/data/models/UserEntity.java
+++ b/api/src/main/java/com/uib/avaluapp/user/infrastructure/data/models/UserEntity.java
@@ -1,6 +1,7 @@
 package com.uib.avaluapp.user.infrastructure.data.models;
 
 import com.uib.avaluapp.project.infrastructure.data.models.ProjectEntity;
+import com.uib.avaluapp.surveys.infrastructure.data.models.SurveyEntity;
 import com.uib.avaluapp.user.domain.models.Role;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,4 +35,7 @@ public class UserEntity {
 
     @OneToMany(mappedBy = "admin", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectEntity> projects;
+
+    @OneToMany(mappedBy = "lead", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private List<SurveyEntity> surveys;
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,7 @@ import { Role } from '@/models/role.model'
 import { useQueries } from '@tanstack/react-query'
 import { PanelProvider } from '@/contexts/PanelContext'
 import { Panel } from '@/components/panel/Panel'
+import { useLoadMasters } from './hooks/useLoadMasters'
 
 const Login = lazy(() => import('@/pages/login/Login'))
 const Private = lazy(() => import('@/pages/private/Private'))
@@ -27,6 +28,8 @@ function App() {
   const [{ isPending }] = useQueries({
     queries: [refreshSessionQueryOptions()],
   })
+
+  useLoadMasters()
 
   useEffect(() => {
     PublicPrivateInterceptor()

--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -6,19 +6,24 @@ import Footer from '@/components/layout/footer/Footer'
 interface LayoutProps {
   children: React.ReactNode
   attributions?: Attribution[]
+  align?: 'center' | 'start' | 'end'
 }
 
-const Layout: React.FC<LayoutProps> = ({ children, attributions }) => {
+const Layout: React.FC<LayoutProps> = ({
+  children,
+  attributions,
+  align = 'center',
+}) => {
   return (
     <>
       <Box
         component='section'
         display='flex'
         flexDirection='column'
-        justifyContent='center'
+        justifyContent={align}
         minHeight='100vh'>
         <Header />
-        <Container maxWidth='lg' sx={{ mt: 5 }}>
+        <Container maxWidth='lg' sx={{ mt: 15 }}>
           {children}
         </Container>
       </Box>

--- a/app/src/constants/endpoints.ts
+++ b/app/src/constants/endpoints.ts
@@ -21,4 +21,10 @@ export const apiEndpoints = {
     delete: (id: number) => `${apiBaseUrl}/projects/${id}`,
     update: (id: number) => `${apiBaseUrl}/projects/${id}`,
   },
+  surveys: {
+    getAll: (projectId: number) => `${apiBaseUrl}/surveys/${projectId}`,
+    create: `${apiBaseUrl}/surveys`,
+    delete: (id: number) => `${apiBaseUrl}/surveys/${id}`,
+    update: (id: number) => `${apiBaseUrl}/surveys/${id}`,
+  },
 }

--- a/app/src/constants/navs.ts
+++ b/app/src/constants/navs.ts
@@ -8,5 +8,14 @@ export const UserNavs: NavItem[] = [
 export const AdminNavs: NavItem[] = [
   { value: 'dashboard', href: `${AdminRoutes.Base}/${AdminRoutes.Dashboard}` },
   { value: 'users', href: `${AdminRoutes.Base}/${AdminRoutes.Users}` },
-  { value: 'projects', href: `${AdminRoutes.Base}/${AdminRoutes.Projects}` },
+  {
+    value: 'projects.title',
+    href: `${AdminRoutes.Base}/${AdminRoutes.Projects}`,
+    children: [
+      {
+        value: 'projects.list',
+        href: `${AdminRoutes.Base}/${AdminRoutes.Projects}`,
+      },
+    ],
+  },
 ]

--- a/app/src/constants/queries.constants.ts
+++ b/app/src/constants/queries.constants.ts
@@ -3,6 +3,7 @@ export const Queries = {
   refresh: 'refresh',
   getProjects: 'getprojects',
   getProject: 'getproject',
+  getSurveys: 'getsurveys',
 }
 
 export default Queries

--- a/app/src/constants/routes.ts
+++ b/app/src/constants/routes.ts
@@ -16,4 +16,5 @@ export const AdminRoutes = {
   Dashboard: 'dashboard',
   Users: 'users',
   Projects: 'projects',
+  ProjectDetail: 'projects/:id',
 }

--- a/app/src/hooks/useLoadMasters.ts
+++ b/app/src/hooks/useLoadMasters.ts
@@ -3,15 +3,18 @@ import { useEffect } from 'react'
 import { useQueries } from '@tanstack/react-query'
 import { setProjects } from '@/redux/states/project'
 import { useDispatch } from 'react-redux'
+import getUsersQueryOptions from '@/pages/admin/pages/users/queries/get.users.query'
+import { setUsers } from '@/redux/states/user'
 
 export const useLoadMasters = () => {
   const dispatch = useDispatch()
 
-  const [{ data: projectsData }] = useQueries({
-    queries: [getAllProjectsQueryOptions()],
+  const [{ data: projectsData }, { data: userData }] = useQueries({
+    queries: [getAllProjectsQueryOptions(), getUsersQueryOptions()],
   })
 
   useEffect(() => {
     if (projectsData) dispatch(setProjects(projectsData || []))
-  }, [projectsData])
+    if (userData) dispatch(setUsers(userData || []))
+  }, [projectsData, userData])
 }

--- a/app/src/hooks/useLoadMasters.ts
+++ b/app/src/hooks/useLoadMasters.ts
@@ -1,0 +1,17 @@
+import getAllProjectsQueryOptions from '@/pages/admin/pages/projects/queries/getAll.project.query'
+import { useEffect } from 'react'
+import { useQueries } from '@tanstack/react-query'
+import { setProjects } from '@/redux/states/project'
+import { useDispatch } from 'react-redux'
+
+export const useLoadMasters = () => {
+  const dispatch = useDispatch()
+
+  const [{ data: projectsData }] = useQueries({
+    queries: [getAllProjectsQueryOptions()],
+  })
+
+  useEffect(() => {
+    if (projectsData) dispatch(setProjects(projectsData || []))
+  }, [projectsData])
+}

--- a/app/src/models/nav.model.ts
+++ b/app/src/models/nav.model.ts
@@ -1,4 +1,6 @@
 export interface NavItem {
   value: string
   href: string
+  children?: NavItem[]
+  unlocated?: boolean
 }

--- a/app/src/models/tab.model.ts
+++ b/app/src/models/tab.model.ts
@@ -1,4 +1,6 @@
+import { JSX } from 'react'
+
 export interface TabModel {
   label: string // Use it as a key for locales
-  component: React.ReactNode
+  component: JSX.Element
 }

--- a/app/src/models/tab.model.ts
+++ b/app/src/models/tab.model.ts
@@ -1,0 +1,4 @@
+export interface TabModel {
+  label: string // Use it as a key for locales
+  component: React.ReactNode
+}

--- a/app/src/pages/admin/Admin.tsx
+++ b/app/src/pages/admin/Admin.tsx
@@ -6,6 +6,9 @@ import { lazy } from 'react'
 const AdminDashboard = lazy(() => import('./pages/dashboard/AdminDashboard'))
 const UsersPage = lazy(() => import('./pages/users/UsersPage'))
 const ProjectsPage = lazy(() => import('./pages/projects/ProjectsPage'))
+const ProjectDetailPage = lazy(
+  () => import('./pages/projectdetail/ProjectDetailPage')
+)
 
 export const Admin = () => {
   return (
@@ -14,6 +17,7 @@ export const Admin = () => {
       <Route path={AdminRoutes.Dashboard} element={<AdminDashboard />} />
       <Route path={AdminRoutes.Users} element={<UsersPage />} />
       <Route path={AdminRoutes.Projects} element={<ProjectsPage />} />
+      <Route path={AdminRoutes.ProjectDetail} element={<ProjectDetailPage />} />
     </RoutesWithNotFound>
   )
 }

--- a/app/src/pages/admin/pages/projectdetail/ProjectDetailPage.tsx
+++ b/app/src/pages/admin/pages/projectdetail/ProjectDetailPage.tsx
@@ -1,0 +1,15 @@
+import Layout from '@/components/layout/Layout'
+import { useParams } from 'react-router-dom'
+import TabManager from './components/tabmanager/TabManager'
+
+export const ProjectDetailPage = () => {
+  const { id } = useParams()
+
+  return (
+    <Layout align='start'>
+      <TabManager id={parseInt(id ?? '0')} />
+    </Layout>
+  )
+}
+
+export default ProjectDetailPage

--- a/app/src/pages/admin/pages/projectdetail/components/grids/SurveyGrid.tsx
+++ b/app/src/pages/admin/pages/projectdetail/components/grids/SurveyGrid.tsx
@@ -1,6 +1,7 @@
 import getAllSurveysQueryOptions from '../../queries/survey/getAll.survey.query'
 import createSurveyQueryOptions from '../../queries/survey/create.survey.query'
 import deleteSurveyQueryOptions from '../../queries/survey/delete.survey.query'
+import updateSurveyQueryOptions from '../../queries/survey/update.survey.query'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 import { usePanel } from '@/contexts/PanelContext'
@@ -14,7 +15,6 @@ import { User } from '@/models/user.model'
 import { dateRenderer } from '@/utils/renderers/date.renderer'
 import Grid from '@/components/grid/Grid'
 import { SurveyForm } from '../panels/SurveyForm'
-import updateSurveyQueryOptions from '../../queries/survey/create.survey.query'
 
 interface SurveyGridProps {
   projectId: number

--- a/app/src/pages/admin/pages/projectdetail/components/grids/SurveyGrid.tsx
+++ b/app/src/pages/admin/pages/projectdetail/components/grids/SurveyGrid.tsx
@@ -1,0 +1,165 @@
+import getAllSurveysQueryOptions from '../../queries/survey/getAll.survey.query'
+import createSurveyQueryOptions from '../../queries/survey/create.survey.query'
+import deleteSurveyQueryOptions from '../../queries/survey/delete.survey.query'
+import DeleteIcon from '@mui/icons-material/Delete'
+import EditIcon from '@mui/icons-material/Edit'
+import { usePanel } from '@/contexts/PanelContext'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { PanelType } from '@/models/panels.model'
+import { Survey } from '../../models/survey.model'
+import { useMemo } from 'react'
+import { GridActionsCellItem, GridColDef } from '@mui/x-data-grid'
+import { User } from '@/models/user.model'
+import { dateRenderer } from '@/utils/renderers/date.renderer'
+import Grid from '@/components/grid/Grid'
+import { SurveyForm } from '../panels/SurveyForm'
+import updateSurveyQueryOptions from '../../queries/survey/create.survey.query'
+
+interface SurveyGridProps {
+  projectId: number
+}
+
+export const SurveyGrid: React.FC<SurveyGridProps> = ({ projectId }) => {
+  const { t } = useTranslation()
+  const { openPanel } = usePanel()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, isFetching } = useQuery(
+    getAllSurveysQueryOptions(projectId)
+  )
+
+  const createMutation = useMutation(createSurveyQueryOptions(queryClient))
+
+  const deleteMutation = useMutation(deleteSurveyQueryOptions(queryClient))
+
+  const updateMutation = useMutation(updateSurveyQueryOptions(queryClient))
+
+  const handleCreate = async (formData: FormData) => {
+    const survey = {
+      name: formData.get('name') as string,
+      projectId: projectId,
+      leadId: formData.get('leadId') as unknown as number,
+    }
+
+    await createMutation.mutateAsync(survey)
+  }
+
+  const onClickCreate = () => {
+    openPanel({
+      type: PanelType.FormDialog,
+      title: t('admin.projectdetail.tabs.surveys.grid.actions.create.title'),
+      content: <SurveyForm />,
+      onSubmit: handleCreate,
+      errorText: t(
+        'admin.projectdetail.tabs.surveys.grid.actions.create.error'
+      ),
+    })
+  }
+
+  const handleDelete = (id: number, name: string) => {
+    openPanel({
+      type: PanelType.ConfirmDialog,
+      title: t(
+        'admin.projectdetail.tabs.surveys.grid.actions.delete.confirm.title'
+      ),
+      text: t(
+        'admin.projectdetail.tabs.surveys.grid.actions.delete.confirm.text',
+        { name }
+      ),
+      confirmText: t(
+        'admin.projectdetail.tabs.surveys.grid.actions.delete.confirm.button.ok'
+      ),
+      cancelText: t(
+        'admin.projectdetail.tabs.surveys.grid.actions.delete.confirm.button.cancel'
+      ),
+      onConfirm: () => deleteMutation.mutate(id),
+    })
+  }
+
+  const handleUpdate = async (formData: FormData) => {
+    const updatedSurvey = {
+      id: formData.get('id') as unknown as number,
+      name: formData.get('name') as string,
+      projectId: projectId,
+      leadId: formData.get('leadId') as unknown as number,
+    }
+
+    await updateMutation.mutateAsync(updatedSurvey)
+  }
+
+  const onClickUpdate = (survey: Survey) => {
+    openPanel({
+      type: PanelType.FormDialog,
+      title: t('admin.projectdetail.tabs.surveys.grid.actions.edit.title'),
+      content: <SurveyForm survey={survey} />,
+      onSubmit: handleUpdate,
+      errorText: t('admin.projectdetail.tabs.surveys.grid.actions.edit.error'),
+    })
+  }
+
+  const columns: GridColDef<Survey>[] = useMemo(
+    () => [
+      {
+        field: 'name',
+        headerName: t('admin.projectdetail.tabs.surveys.grid.columns.name'),
+        flex: 1,
+      },
+      {
+        field: 'lead',
+        headerName: t('admin.projectdetail.tabs.surveys.grid.columns.lead'),
+        valueGetter: (value: User) => value.username,
+        flex: 1,
+      },
+      {
+        field: 'urlCode',
+        headerName: t('admin.projectdetail.tabs.surveys.grid.columns.urlCode'),
+        flex: 1,
+      },
+      {
+        field: 'createdAt',
+        headerName: t(
+          'admin.projectdetail.tabs.surveys.grid.columns.createdAt'
+        ),
+        flex: 1,
+        valueGetter: (value: string) => dateRenderer(new Date(value)),
+      },
+      {
+        field: 'actions',
+        type: 'actions',
+        minWidth: 140,
+        getActions: (params: { row: Survey }) => [
+          <GridActionsCellItem
+            icon={<DeleteIcon />}
+            onClick={() => handleDelete(params.row.id, params.row.name)}
+            label={t(
+              'admin.projectdetail.tabs.surveys.grid.actions.delete.label'
+            )}
+          />,
+          <GridActionsCellItem
+            icon={<EditIcon />}
+            onClick={() => onClickUpdate(params.row)}
+            label={t(
+              'admin.projectdetail.tabs.surveys.grid.actions.edit.label'
+            )}
+          />,
+        ],
+      },
+    ],
+    [t]
+  )
+
+  return (
+    <Grid
+      isLoading={isLoading || isFetching}
+      rows={data ?? []}
+      columns={columns}
+      createButton={{
+        onClick: onClickCreate,
+        label: t('admin.projectdetail.tabs.surveys.grid.actions.create.label'),
+      }}
+    />
+  )
+}
+
+export default SurveyGrid

--- a/app/src/pages/admin/pages/projectdetail/components/panels/SurveyForm.tsx
+++ b/app/src/pages/admin/pages/projectdetail/components/panels/SurveyForm.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next'
+import { Survey } from '../../models/survey.model'
+import {
+  Autocomplete,
+  FormControl,
+  FormLabel,
+  Stack,
+  TextField,
+} from '@mui/material'
+import { User } from '@/models/user.model'
+import { useMemo, useState } from 'react'
+import store from '@/redux/store'
+import { Role } from '@/models/role.model'
+
+interface SurveyFormProps {
+  survey?: Survey
+}
+
+export const SurveyForm: React.FC<SurveyFormProps> = ({ survey }) => {
+  const { t } = useTranslation()
+
+  const [selectedLeadId, setSelectedLeadId] = useState<number>(
+    survey?.lead?.id ?? 0
+  )
+
+  const users = store.getState().user.user
+  const leads: User[] = useMemo(
+    () => users.filter((u) => u.role === Role.User),
+    [users]
+  )
+
+  return (
+    <Stack direction='column' spacing={3} width='100%' height='100%'>
+      <input type='hidden' name='leadId' value={selectedLeadId} />
+
+      <FormControl sx={{ display: 'none' }}>
+        <FormLabel htmlFor='id'>
+          {t('admin.projectdetail.tabs.surveys.form.fields.id.label')}
+        </FormLabel>
+        <TextField
+          id='id'
+          name='id'
+          fullWidth
+          variant='outlined'
+          defaultValue={survey?.id}
+        />
+      </FormControl>
+      <FormControl>
+        <FormLabel htmlFor='name'>
+          {t('admin.projectdetail.tabs.surveys.form.fields.name.label')}
+        </FormLabel>
+        <TextField
+          id='name'
+          name='name'
+          placeholder={t(
+            'admin.projectdetail.tabs.surveys.form.fields.name.placeholder'
+          )}
+          autoFocus
+          required
+          fullWidth
+          variant='outlined'
+          defaultValue={survey?.name}
+        />
+      </FormControl>
+      <FormControl>
+        <FormLabel htmlFor='lead'>
+          {t('admin.projectdetail.tabs.surveys.form.fields.lead.label')}
+        </FormLabel>
+        <Autocomplete
+          id='lead'
+          options={leads}
+          getOptionLabel={(option) => option.username}
+          defaultValue={leads.find((l) => l.id === survey?.lead?.id) || null}
+          onChange={(_, value) => {
+            setSelectedLeadId(value?.id ?? 0)
+          }}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          sx={{ '& .MuiAutocomplete-endAdornment': { display: 'none' } }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              placeholder={t(
+                'admin.projectdetail.tabs.surveys.form.fields.lead.placeholder'
+              )}
+              variant='outlined'
+              fullWidth
+            />
+          )}
+        />
+      </FormControl>
+    </Stack>
+  )
+}

--- a/app/src/pages/admin/pages/projectdetail/components/tabmanager/TabManager.tsx
+++ b/app/src/pages/admin/pages/projectdetail/components/tabmanager/TabManager.tsx
@@ -1,0 +1,38 @@
+import { Box, Stack, Tab, Tabs } from '@mui/material'
+import { useState } from 'react'
+import { getAdminProjectTabs } from '../../constants/admin.project.tabs'
+import { useTranslation } from 'react-i18next'
+
+interface TabManagerProps {
+  id: number
+}
+
+export const TabManager: React.FC<TabManagerProps> = ({ id }) => {
+  const [activeTab, setActiveTab] = useState(0)
+  const { t } = useTranslation()
+
+  const handleChange = (_: React.SyntheticEvent, newValue: number) => {
+    setActiveTab(newValue)
+  }
+
+  const adminProjectTabs = getAdminProjectTabs(id)
+
+  return (
+    <Stack spacing={2} direction='column'>
+      <Stack direction='row' justifyContent='center' width='100%'>
+        <Tabs value={activeTab} onChange={handleChange}>
+          {adminProjectTabs.map((tab, index) => (
+            <Tab
+              key={index}
+              label={t(`admin.projectdetail.tabs.${tab.label}.label`)}
+            />
+          ))}
+        </Tabs>
+      </Stack>
+
+      <Box sx={{ mt: 2 }}>{adminProjectTabs[activeTab].component}</Box>
+    </Stack>
+  )
+}
+
+export default TabManager

--- a/app/src/pages/admin/pages/projectdetail/components/tabs/SurveyTab.tsx
+++ b/app/src/pages/admin/pages/projectdetail/components/tabs/SurveyTab.tsx
@@ -1,0 +1,9 @@
+import SurveyGrid from '../grids/SurveyGrid'
+
+interface SurveyTabProps {
+  id: number
+}
+
+export const SurveyTab: React.FC<SurveyTabProps> = ({ id }) => {
+  return <SurveyGrid projectId={id} />
+}

--- a/app/src/pages/admin/pages/projectdetail/constants/admin.project.tabs.tsx
+++ b/app/src/pages/admin/pages/projectdetail/constants/admin.project.tabs.tsx
@@ -1,0 +1,13 @@
+import { TabModel } from '@/models/tab.model'
+import { SurveyTab } from '../components/tabs/SurveyTab'
+
+export const getAdminProjectTabs = (id: number): TabModel[] => [
+  {
+    label: 'surveys',
+    component: <SurveyTab id={id} />,
+  },
+  {
+    label: 'surveys', // Duplicate for demonstration, can be replaced with other tabs
+    component: <SurveyTab id={id} />,
+  },
+]

--- a/app/src/pages/admin/pages/projectdetail/models/survey.model.ts
+++ b/app/src/pages/admin/pages/projectdetail/models/survey.model.ts
@@ -1,0 +1,18 @@
+import { User } from '@/models/user.model'
+import { Project } from '../../projects/models/project.model'
+
+export interface Survey {
+  id: number
+  name: string
+  urlCode: string
+  project: Project
+  lead: User
+  createdAt?: string
+}
+
+export interface SurveyRequest {
+  id?: number
+  name: string
+  projectId: number
+  leadId: number
+}

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/create.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/create.survey.query.ts
@@ -1,15 +1,14 @@
 import { MutationOptions, QueryClient } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 import { SurveyRequest } from '../../models/survey.model'
-import { updateSurvey } from '../../services/survey/update.surveys.service'
 import Queries from '@/constants/queries.constants'
+import { createSurvey } from '../../services/survey/create.surveys.service'
 
-export default function updateSurveyQueryOptions(
+export default function createSurveyQueryOptions(
   queryClient: QueryClient
 ): MutationOptions<AxiosResponse<any, any>, Error, SurveyRequest> {
   return {
-    mutationFn: (variables: SurveyRequest) =>
-      updateSurvey(variables.id ?? 0, variables),
+    mutationFn: (request: SurveyRequest) => createSurvey(request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
     },

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/create.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/create.survey.query.ts
@@ -1,0 +1,20 @@
+import { MutationOptions, QueryClient } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+import { SurveyRequest } from '../../models/survey.model'
+import { updateSurvey } from '../../services/survey/update.surveys.service'
+import Queries from '@/constants/queries.constants'
+
+export default function updateSurveyQueryOptions(
+  queryClient: QueryClient
+): MutationOptions<AxiosResponse<any, any>, Error, SurveyRequest> {
+  return {
+    mutationFn: (variables: SurveyRequest) =>
+      updateSurvey(variables.id ?? 0, variables),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
+    },
+    onError: (error) => {
+      console.error('Error creating survey:', error)
+    },
+  }
+}

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/delete.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/delete.survey.query.ts
@@ -1,0 +1,19 @@
+import { MutationOptions, QueryClient } from '@tanstack/react-query'
+import Queries from '@/constants/queries.constants'
+import { deleteSurvey } from '../../services/survey/delete.surveys.service'
+
+export default function deleteSurveyQueryOptions(
+  queryClient: QueryClient
+): MutationOptions<void, Error, number> {
+  return {
+    mutationFn: async (id: number) => {
+      await deleteSurvey(id)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
+    },
+    onError: (error) => {
+      console.error('Error deleting project:', error)
+    },
+  }
+}

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/delete.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/delete.survey.query.ts
@@ -13,7 +13,7 @@ export default function deleteSurveyQueryOptions(
       queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
     },
     onError: (error) => {
-      console.error('Error deleting project:', error)
+      console.error('Error deleting survey:', error)
     },
   }
 }

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/getAll.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/getAll.survey.query.ts
@@ -1,0 +1,11 @@
+import Queries from '@/constants/queries.constants'
+import { queryOptions } from '@tanstack/react-query'
+import { getAllSurveys } from '../../services/survey/getAll.surveys.service'
+
+export default function getAllSurveysQueryOptions(projectId: number) {
+  return queryOptions({
+    queryKey: [Queries.getSurveys, projectId],
+    queryFn: () => getAllSurveys(projectId),
+    select: (data) => data.data.data,
+  })
+}

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
@@ -14,7 +14,7 @@ export default function updateSurveyQueryOptions(
       queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
     },
     onError: (error) => {
-      console.error('Error creating survey:', error)
+      console.error('Error updating survey:', error)
     },
   }
 }

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
@@ -1,24 +1,20 @@
 import { MutationOptions, QueryClient } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import Queries from '@/constants/queries.constants'
 import { SurveyRequest } from '../../models/survey.model'
 import { updateSurvey } from '../../services/survey/update.surveys.service'
+import Queries from '@/constants/queries.constants'
 
 export default function updateSurveyQueryOptions(
   queryClient: QueryClient
 ): MutationOptions<AxiosResponse<any, any>, Error, SurveyRequest> {
   return {
-    mutationFn: (survey: SurveyRequest) =>
-      updateSurvey(survey.id as number, {
-        name: survey.name,
-        projectId: survey.projectId,
-        leadId: survey.leadId,
-      }),
+    mutationFn: (request: SurveyRequest) =>
+      updateSurvey(request.id ?? 0, request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
     },
     onError: (error) => {
-      console.error('Error updating survey:', error)
+      console.error('Error creating survey:', error)
     },
   }
 }

--- a/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
+++ b/app/src/pages/admin/pages/projectdetail/queries/survey/update.survey.query.ts
@@ -1,0 +1,24 @@
+import { MutationOptions, QueryClient } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
+import Queries from '@/constants/queries.constants'
+import { SurveyRequest } from '../../models/survey.model'
+import { updateSurvey } from '../../services/survey/update.surveys.service'
+
+export default function updateSurveyQueryOptions(
+  queryClient: QueryClient
+): MutationOptions<AxiosResponse<any, any>, Error, SurveyRequest> {
+  return {
+    mutationFn: (survey: SurveyRequest) =>
+      updateSurvey(survey.id as number, {
+        name: survey.name,
+        projectId: survey.projectId,
+        leadId: survey.leadId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [Queries.getSurveys] })
+    },
+    onError: (error) => {
+      console.error('Error updating survey:', error)
+    },
+  }
+}

--- a/app/src/pages/admin/pages/projectdetail/services/survey/create.surveys.service.ts
+++ b/app/src/pages/admin/pages/projectdetail/services/survey/create.surveys.service.ts
@@ -1,0 +1,7 @@
+import axios from 'axios'
+import { SurveyRequest } from '../../models/survey.model'
+import { apiEndpoints } from '@/constants/endpoints'
+
+export const createSurvey = async (request: SurveyRequest) => {
+  return axios.post(apiEndpoints.surveys.create, request)
+}

--- a/app/src/pages/admin/pages/projectdetail/services/survey/delete.surveys.service.ts
+++ b/app/src/pages/admin/pages/projectdetail/services/survey/delete.surveys.service.ts
@@ -1,0 +1,6 @@
+import { apiEndpoints } from '@/constants/endpoints'
+import axios from 'axios'
+
+export const deleteSurvey = async (id: number) => {
+  return axios.delete(apiEndpoints.surveys.delete(id))
+}

--- a/app/src/pages/admin/pages/projectdetail/services/survey/getAll.surveys.service.ts
+++ b/app/src/pages/admin/pages/projectdetail/services/survey/getAll.surveys.service.ts
@@ -1,0 +1,6 @@
+import { apiEndpoints } from '@/constants/endpoints'
+import axios from 'axios'
+
+export const getAllSurveys = async (projectId: number) => {
+  return axios.get(apiEndpoints.surveys.getAll(projectId))
+}

--- a/app/src/pages/admin/pages/projectdetail/services/survey/update.surveys.service.ts
+++ b/app/src/pages/admin/pages/projectdetail/services/survey/update.surveys.service.ts
@@ -1,0 +1,7 @@
+import { apiEndpoints } from '@/constants/endpoints'
+import axios from 'axios'
+import { SurveyRequest } from '../../models/survey.model'
+
+export const updateSurvey = async (id: number, request: SurveyRequest) => {
+  return axios.put(apiEndpoints.surveys.update(id), request)
+}

--- a/app/src/pages/admin/pages/projects/components/grid/ProjectsGrid.tsx
+++ b/app/src/pages/admin/pages/projects/components/grid/ProjectsGrid.tsx
@@ -1,6 +1,7 @@
 import Grid from '@/components/grid/Grid'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 import ProjectForm from '../panels/ProjectForm'
 import getAllProjectsQueryOptions from '../../queries/getAll.project.query'
 import createProjectQueryOptions from '../../queries/create.project.query'
@@ -8,7 +9,6 @@ import { GridActionsCellItem, GridColDef } from '@mui/x-data-grid'
 import { Project, ProjectBase } from '../../models/project.model'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { User } from '@/models/user.model'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Box, Tooltip, Typography } from '@mui/material'
 import { dateRenderer } from '@/utils/renderers/date.renderer'
@@ -16,11 +16,13 @@ import { usePanel } from '@/contexts/PanelContext'
 import { PanelType } from '@/models/panels.model'
 import deleteProjectQueryOptions from '../../queries/delete.project.query'
 import updateProjectQueryOptions from '../../queries/update.project.query'
+import { useNavigate } from 'react-router-dom'
 
 export const ProjectsGrid = () => {
   const { t } = useTranslation()
   const { openPanel } = usePanel()
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
   const { data, isLoading, isFetching } = useQuery(getAllProjectsQueryOptions())
 
@@ -80,17 +82,25 @@ export const ProjectsGrid = () => {
     })
   }
 
+  const handleOpenDetail = (project: Project) => {
+    navigate(project.id.toString())
+  }
+
+  const onItemDoubleClick = (params: { row: Project }) => {
+    handleOpenDetail(params.row)
+  }
+
   const columns: GridColDef<Project>[] = useMemo(
     () => [
       {
         field: 'name',
         headerName: t('admin.projects.grid.columns.name'),
-        minWidth: 200,
+        flex: 1,
       },
       {
         field: 'description',
         headerName: t('admin.projects.grid.columns.description'),
-        minWidth: 400,
+        flex: 2,
         renderCell: (params) => (
           <Tooltip title={params.value || ''}>
             <Box
@@ -117,22 +127,23 @@ export const ProjectsGrid = () => {
       {
         field: 'createdAt',
         headerName: t('admin.projects.grid.columns.createdAt'),
-        minWidth: 150,
+        flex: 1,
         renderCell: (params) => {
           const date = new Date(params.value)
           return dateRenderer(date)
         },
       },
-      {
-        field: 'admin',
-        headerName: t('admin.projects.grid.columns.admin'),
-        minWidth: 200,
-        valueGetter: (value: User) => value.username,
-      },
+      // Redundant because admins only see their own projects
+      // {
+      //   field: 'admin',
+      //   headerName: t('admin.projects.grid.columns.admin'),
+      //   minWidth: 200,
+      //   valueGetter: (value: User) => value.username,
+      // },
       {
         field: 'actions',
         type: 'actions',
-        minWidth: 80,
+        minWidth: 140,
         getActions: (params: { row: Project }) => [
           <GridActionsCellItem
             icon={<DeleteIcon />}
@@ -143,6 +154,11 @@ export const ProjectsGrid = () => {
             icon={<EditIcon />}
             onClick={() => onClickUpdate(params.row)}
             label={t('admin.projects.grid.actions.update.label')}
+          />,
+          <GridActionsCellItem
+            icon={<VisibilityIcon />}
+            onClick={() => handleOpenDetail(params.row)}
+            label={t('admin.projects.grid.actions.view.label')}
           />,
         ],
       },
@@ -159,6 +175,7 @@ export const ProjectsGrid = () => {
         onClick: onClickCreate,
         label: t('admin.projects.grid.actions.create.label'),
       }}
+      onRowDoubleClick={onItemDoubleClick}
     />
   )
 }

--- a/app/src/redux/states/project.ts
+++ b/app/src/redux/states/project.ts
@@ -1,0 +1,22 @@
+import { Project } from '@/pages/admin/pages/projects/models/project.model'
+import { createSlice } from '@reduxjs/toolkit'
+
+export interface ProjectState {
+  projects: Project[]
+}
+
+export const ProjectEmptyState: ProjectState = {
+  projects: [],
+}
+
+export const projectSlice = createSlice({
+  name: 'project',
+  initialState: ProjectEmptyState,
+  reducers: {
+    setProjects: (_state, action) => ({ ..._state, projects: action.payload }),
+    clearProjects: () => ProjectEmptyState,
+  },
+})
+
+export const { setProjects, clearProjects } = projectSlice.actions
+export default projectSlice.reducer

--- a/app/src/redux/states/user.ts
+++ b/app/src/redux/states/user.ts
@@ -1,0 +1,22 @@
+import { User } from '@/models/user.model'
+import { createSlice } from '@reduxjs/toolkit'
+
+export interface UserState {
+  user: User[]
+}
+
+export const UserEmptyState: UserState = {
+  user: [],
+}
+
+export const userSlice = createSlice({
+  name: 'user',
+  initialState: UserEmptyState,
+  reducers: {
+    setUsers: (_state, action) => ({ ..._state, user: action.payload }),
+    clearUsers: () => UserEmptyState,
+  },
+})
+
+export const { setUsers, clearUsers } = userSlice.actions
+export default userSlice.reducer

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
 import authReducer from '@/redux/states/auth'
+import projectReducer from '@/redux/states/project'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    project: projectReducer,
   },
 })
 

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit'
 import authReducer from '@/redux/states/auth'
 import projectReducer from '@/redux/states/project'
+import userReducer from '@/redux/states/user'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     project: projectReducer,
+    user: userReducer,
   },
 })
 

--- a/app/src/translation/locales/ca.json
+++ b/app/src/translation/locales/ca.json
@@ -422,7 +422,60 @@
     "projectdetail": {
       "tabs": {
         "surveys": {
-          "label": "Enquestes"
+          "label": "Enquestes",
+          "grid": {
+            "columns": {
+              "name": "Nom",
+              "lead": "Responsable",
+              "urlCode": "Codi URL",
+              "createdAt": "Data de creació"
+            },
+            "actions": {
+              "create": {
+                "label": "Crear enquesta",
+                "title": "Crear una nova enquesta",
+                "error": "Error en crear l'enquesta. Si us plau, torna-ho a intentar més tard."
+              },
+              "edit": {
+                "label": "Editar",
+                "title": "Editar enquesta",
+                "error": "Error en actualitzar l'enquesta. Si us plau, torna-ho a intentar més tard."
+              },
+              "delete": {
+                "label": "Eliminar",
+                "confirm": {
+                  "title": "Eliminar enquesta",
+                  "text": "Estàs segur que vols eliminar l'enquesta {{name}}?",
+                  "button": {
+                    "ok": "Eliminar",
+                    "cancel": "Cancel·lar"
+                  }
+                }
+              }
+            }
+          },
+          "form": {
+            "title": {
+              "create": "Crear enquesta",
+              "edit": "Editar enquesta"
+            },
+            "fields": {
+              "name": {
+                "label": "Nom de l'enquesta",
+                "placeholder": "Introdueix el nom de l'enquesta",
+                "helperText": "El nom de l'enquesta és obligatori"
+              },
+              "lead": {
+                "label": "Responsable de l'enquesta",
+                "placeholder": "Selecciona un responsable",
+                "helperText": "El responsable és obligatori"
+              }
+            },
+            "error": {
+              "create": "Error en crear l'enquesta. Ja existeix una enquesta amb aquest nom.",
+              "update": "Error en actualitzar l'enquesta. Ja existeix una altra enquesta amb aquest nom."
+            }
+          }
         }
       }
     }

--- a/app/src/translation/locales/ca.json
+++ b/app/src/translation/locales/ca.json
@@ -10,7 +10,10 @@
       "navs": {
         "dashboard": "Tauler de control",
         "users": "Usuaris",
-        "projects": "Projectes"
+        "projects": {
+          "title": "Projectes",
+          "list": "Gestionar projectes"
+        }
       }
     },
     "formatters": {

--- a/app/src/translation/locales/ca.json
+++ b/app/src/translation/locales/ca.json
@@ -418,6 +418,13 @@
           "update": "Error en actualitzar el projecte. Si us plau, torna-ho a intentar més tard."
         }
       }
+    },
+    "projectdetail": {
+      "tabs": {
+        "surveys": {
+          "label": "Enquestes"
+        }
+      }
     }
   }
 }

--- a/app/src/translation/locales/en.json
+++ b/app/src/translation/locales/en.json
@@ -418,6 +418,13 @@
           "update": "Error updating project. Another project already exists with this name."
         }
       }
+    },
+    "projectdetail": {
+      "tabs": {
+        "surveys": {
+          "label": "Surveys"
+        }
+      }
     }
   }
 }

--- a/app/src/translation/locales/en.json
+++ b/app/src/translation/locales/en.json
@@ -10,7 +10,10 @@
       "navs": {
         "dashboard": "Dashboard",
         "users": "Users",
-        "projects": "Projects"
+        "projects": {
+          "title": "Projects",
+          "list": "Manage Projects"
+        }
       }
     },
     "formatters": {

--- a/app/src/translation/locales/en.json
+++ b/app/src/translation/locales/en.json
@@ -422,7 +422,60 @@
     "projectdetail": {
       "tabs": {
         "surveys": {
-          "label": "Surveys"
+          "label": "Surveys",
+          "grid": {
+            "columns": {
+              "name": "Name",
+              "lead": "Responsible",
+              "urlCode": "URL Code",
+              "createdAt": "Creation Date"
+            },
+            "actions": {
+              "create": {
+                "label": "Create survey",
+                "title": "Create new survey",
+                "error": "Error creating the survey. Please try again later."
+              },
+              "edit": {
+                "label": "Edit",
+                "title": "Edit survey",
+                "error": "Error updating the survey. Please try again later."
+              },
+              "delete": {
+                "label": "Delete",
+                "confirm": {
+                  "title": "Delete survey",
+                  "text": "Are you sure you want to delete the survey {{name}}?",
+                  "button": {
+                    "ok": "Delete",
+                    "cancel": "Cancel"
+                  }
+                }
+              }
+            }
+          },
+          "form": {
+            "title": {
+              "create": "Create survey",
+              "edit": "Edit survey"
+            },
+            "fields": {
+              "name": {
+                "label": "Survey name",
+                "placeholder": "Enter the survey name",
+                "helperText": "The survey name is required"
+              },
+              "lead": {
+                "label": "Survey responsible",
+                "placeholder": "Select a responsible person",
+                "helperText": "The responsible person is required"
+              }
+            },
+            "error": {
+              "create": "Error creating the survey. A survey with this name already exists.",
+              "update": "Error updating the survey. Another survey with this name already exists."
+            }
+          }
         }
       }
     }

--- a/app/src/translation/locales/es.json
+++ b/app/src/translation/locales/es.json
@@ -422,6 +422,13 @@
           "update": "Error al actualizar el proyecto. Ya existe otro proyecto con este nombre."
         }
       }
+    },
+    "projectdetail": {
+      "tabs": {
+        "surveys": {
+          "label": "Encuestas"
+        }
+      }
     }
   }
 }

--- a/app/src/translation/locales/es.json
+++ b/app/src/translation/locales/es.json
@@ -426,7 +426,60 @@
     "projectdetail": {
       "tabs": {
         "surveys": {
-          "label": "Encuestas"
+          "label": "Encuestas",
+          "grid": {
+            "columns": {
+              "name": "Nombre",
+              "lead": "Responsable",
+              "urlCode": "Código de URL",
+              "createdAt": "Fecha de creación"
+            },
+            "actions": {
+              "create": {
+                "label": "Crear encuesta",
+                "title": "Crear nueva encuesta",
+                "error": "Error al crear la encuesta. Por favor, inténtalo de nuevo más tarde."
+              },
+              "edit": {
+                "label": "Editar",
+                "title": "Editar encuesta",
+                "error": "Error al actualizar la encuesta. Por favor, inténtalo de nuevo más tarde."
+              },
+              "delete": {
+                "label": "Eliminar",
+                "confirm": {
+                  "title": "Eliminar encuesta",
+                  "text": "¿Estás seguro de que deseas eliminar la encuesta {{name}}?",
+                  "button": {
+                    "ok": "Eliminar",
+                    "cancel": "Cancelar"
+                  }
+                }
+              }
+            }
+          },
+          "form": {
+            "title": {
+              "create": "Crear encuesta",
+              "edit": "Editar encuesta"
+            },
+            "fields": {
+              "name": {
+                "label": "Nombre de la encuesta",
+                "placeholder": "Introduce el nombre de la encuesta",
+                "helperText": "El nombre de la encuesta es obligatorio"
+              },
+              "lead": {
+                "label": "Responsable de la encuesta",
+                "placeholder": "Selecciona un responsable",
+                "helperText": "El responsable es obligatorio"
+              }
+            },
+            "error": {
+              "create": "Error al crear la encuesta. Ya existe una encuesta con este nombre.",
+              "update": "Error al actualizar la encuesta. Ya existe otra encuesta con este nombre."
+            }
+          }
         }
       }
     }

--- a/app/src/translation/locales/es.json
+++ b/app/src/translation/locales/es.json
@@ -10,7 +10,10 @@
       "navs": {
         "dashboard": "Panel de control",
         "users": "Usuarios",
-        "projects": "Proyectos"
+        "projects": {
+          "title": "Proyectos",
+          "list": "Gestionar proyectos"
+        }
       }
     },
     "formatters": {


### PR DESCRIPTION
This pull request introduces a comprehensive implementation of the survey management feature in the application. Key changes include the addition of survey-related domain models, services, repository, and controllers, as well as updates to existing entities to integrate surveys into the project and user domains. Below is a summary of the most important changes grouped by theme.

### Survey Domain Models and Enums
* Added the `Survey` domain model to represent survey data, including attributes such as `id`, `name`, `createdAt`, `urlCode`, `status`, `lead`, and `project`. (`[api/src/main/java/com/uib/avaluapp/surveys/domain/models/Survey.javaR1-R20](diffhunk://#diff-1cb2f247a2c35c99340b3e451be2c16ca1e3ee6e7ad09bab4f5ca19665ec0142R1-R20)`)
* Introduced the `SurveyStatus` enum with values `PENDING`, `REJECTED`, and `ACCEPTED` to track survey states. (`[api/src/main/java/com/uib/avaluapp/surveys/domain/models/SurveyStatus.javaR1-R7](diffhunk://#diff-5b963a4c5297dddeeeef66ba3a4f7af08b71380b9f0187870c7f0a83a19d608aR1-R7)`)

### Survey Entity and Repository
* Created `SurveyEntity` to map survey data to the database, including relationships with `UserEntity` (lead) and `ProjectEntity` (project). (`[api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/models/SurveyEntity.javaR1-R56](diffhunk://#diff-a08af6ab422202e87fcebe36bf42e7611e6d6b912e27af9fd7c0a51762000f2bR1-R56)`)
* Added the `SurveyRepository` interface with methods to fetch surveys by project ID and retrieve surveys with their associated lead or project. (`[api/src/main/java/com/uib/avaluapp/surveys/infrastructure/data/repository/SurveyRepository.javaR1-R19](diffhunk://#diff-77d766f934569cca2ab18145e9b5cd97537ee44e42bc294b2aae44e04a2383c1R1-R19)`)

### Survey Services and Ports
* Defined the `SurveyService` interface and implemented it in `SurveyServiceImpl` to handle survey creation, retrieval, deletion, and updates, with authorization checks based on project admin roles. (`[[1]](diffhunk://#diff-52a8594f6b11ad433d167a14b08f46171add30ab69cd7c9bc9a1990ea03d99daR1-R16)`, `[[2]](diffhunk://#diff-0b8f35d0d6dac8e694ad995e5c7306bd2a62c469ad68fb231363e3f9d9f4f5f3R1-R94)`)
* Introduced the `SurveyPort` interface and its implementation in `SurveyAdapter` to abstract persistence operations for surveys. (`[[1]](diffhunk://#diff-89e9ec21accbd5dd39e491c5be0a5974586550a40aa34132cee242b55249a4e3R1-R19)`, `[[2]](diffhunk://#diff-1de2ef5399a89b893c5d3f810da3bc57f2fd6ea0946f14161072ab50c53e3eadR1-R69)`)

### Survey Controller and Web Layer
* Added `SurveyController` to expose REST endpoints for survey operations, including retrieval by project ID, creation, deletion, and updates. (`[api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyController.javaR1-R87](diffhunk://#diff-852c2041fb809ca4dc63fb75aa1a5813e550e8513b105e6580e50dec2182722dR1-R87)`)
* Implemented `SurveyDtoMapper` to map between `Survey` domain models and `SurveyDto` responses. (`[api/src/main/java/com/uib/avaluapp/surveys/infrastructure/web/SurveyDtoMapper.javaR1-R19](diffhunk://#diff-a4d9fce767a9f7943efc475f8f395d53b69d7c07d15bbbca0158a3931ae92c14R1-R19)`)
* Created `CreateSurveyRequest` and `SurveyDto` classes for handling survey-related requests and responses. (`[[1]](diffhunk://#diff-e8410471c31b296c8ca690b6caeea8f9aa4e06a2169a352b0ba3d070c1dcd895R1-R12)`, `[[2]](diffhunk://#diff-2c95ed80d9a09ba13475a750028dab7d050ac9846750fb328a1f815c51aaf282R1-R18)`)

### Integration with Existing Entities
* Updated `ProjectEntity` to include a one-to-many relationship with `SurveyEntity`. (`[api/src/main/java/com/uib/avaluapp/project/infrastructure/data/models/ProjectEntity.javaR36-R38](diffhunk://#diff-cd55cf0f51651688c6aa5ed8d421ec03ee301179c3e984d88722a262664fe767R36-R38)`)
* Modified `UserEntity` to add a one-to-many relationship with `SurveyEntity` for users acting as survey leads. (`[api/src/main/java/com/uib/avaluapp/user/infrastructure/data/models/UserEntity.javaR38-R40](diffhunk://#diff-ac7255e6b2a3adaa1df8dfa54d0b1282cf7a3a4e17c22df0ad4ff5e2a22e0262R38-R40)`)